### PR TITLE
fix: Typo at the end of `gh_api_url`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -150,7 +150,7 @@ runs:
         if [[ "${{ inputs.version }}" == "latest" ]]; then
           gh_api_url="https://api.github.com/repos/${{ inputs.repository }}/releases/latest"
         else
-          gh_api_url="https://api.github.com/repos/${{ inputs.repository }}/releases/tags/${{ inputs.version }}$"
+          gh_api_url="https://api.github.com/repos/${{ inputs.repository }}/releases/tags/${{ inputs.version }}"
         fi
 
         release_json_data=$(curl ${token:+"-H"} ${token:+"Authorization: token ${token}"} "$gh_api_url")


### PR DESCRIPTION
I've tried to use your action and it works fine when `version` input is set to `latest` but when I tried to get data of a specific release all action outputs were `null`.

During a quick debug I've noticed that `gh_api_url` had a strange `$` at the end which should not be there according to the [documentation](https://docs.github.com/en/rest/releases/releases#get-the-latest-release).

I've removed it and tested my fork and it seems it works fine.