### PR TITLE
fix: update output description and add shell comments text highlighting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ outputs:
   author_json:
     description: >
       The `author_json` output from release. It's a multiline output, which is packed in a JSON object.
-      The output can be used with the `fromJSON` function `(steps.<id>.outputs.assets_array_json)`.
+      The output can be used with the `fromJSON` function `(steps.<id>.outputs.author_json)`.
     value: ${{ steps.release_data.outputs.author_json }}
 
 runs:
@@ -136,7 +136,7 @@ runs:
     - name: Get release data
       id: release_data
       shell: bash
-      run: |
+      run: | # shell
         echo "::group::Fetch data"
 
         log_token_toggle=""
@@ -215,7 +215,7 @@ runs:
       id: markdown_body
       shell: bash
       if: ${{ inputs.body-markdown-file-path  != '' }}
-      run: |
+      run: | # shell
         echo "::group::Create release markdown file"
 
         log_token_toggle=""
@@ -242,7 +242,7 @@ runs:
       id: release_asset_download
       if: ${{ inputs.asset-file  != '' }}
       shell: bash
-      run: |
+      run: | # shell
         echo "::group::Download release artifacts"
         if [[ ! -d "${{ inputs.asset-output }}" ]]; then
           echo "::error title=Asset output path does not exist.::No ouput path definied."
@@ -303,7 +303,7 @@ runs:
 
     - name: show output values
       shell: bash
-      run: |
+      run: | # shell
         echo "::group::output values"
 
         echo "INFO: Release url ${{ steps.release_data.outputs.url }}"


### PR DESCRIPTION
This pull request includes changes to the `action.yml` file to improve the clarity and accuracy of the shell script annotations and output descriptions. The most important changes include updating the description of the `author_json` output and adding comments to indicate the shell language used in the `runs:` sections for text highlighting.

Updates to output descriptions:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L130-R130): Corrected the description of the `author_json` output to refer to the correct output key.

Improvements to shell script annotations:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L139-R139): Added `# shell` comments to the `run:` sections to clearly indicate the shell language being used. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L139-R139) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L218-R218) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L245-R245) [[4]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L306-R306)