### PR TITLE
Fixed a problem when saving the release body content in the Markdown file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -213,6 +213,8 @@ runs:
 
     - name: Write markdown body file
       id: markdown_body
+      env:
+        BODY_JSON: ${{ steps.release_data.outputs.body }}
       shell: bash
       if: ${{ inputs.body-markdown-file-path  != '' }}
       run: | # shell
@@ -229,10 +231,9 @@ runs:
 
         echo "::add-mask::$log_token_toggle"
         echo "::stop-commands::$log_token_toggle"
+        
+        printf '%s' "$BODY_JSON" | jq -r . > "${{ inputs.body-markdown-file-path }}"
 
-        {
-          echo '${{ fromJSON(steps.release_data.outputs.body) }}'
-        } >> ${{ inputs.body-markdown-file-path }}
         echo "::$log_token_toggle::"
         
         echo "::notice title=Release Markdown file of ${{ inputs.repository }}::Saved body content to file '${{ inputs.body-markdown-file-path }}'"


### PR DESCRIPTION
This pull request includes changes to the `action.yml` file to improve the handling of environment variables and the processing of JSON data for writing markdown body files.

Improvements to environment variable handling and JSON processing:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R216-R217): Added `BODY_JSON` environment variable to store the release data body output.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L233-R236): Replaced the method of writing the body content to the markdown file with a more efficient `printf` and `jq` command.